### PR TITLE
Exposed histeresis parameters to node configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.tgz
 my.md
+*.iml
+.idea
+node_modules

--- a/mixing-valve/locales/de-DE/mixing-valve.json
+++ b/mixing-valve/locales/de-DE/mixing-valve.json
@@ -13,7 +13,11 @@
             "open": "Öffnen (100%)",
             "close": "Schließen (0%)",
             "heating": "Heizen (normal)",
-            "cooling": "Kühlen (invertiert)"
+            "cooling": "Kühlen (invertiert)",
+
+            "precision": "Hysterese (Präzision)",
+            "max_change_percent": "Max Positionsänderung",
+            "max_change_temp_difference": "Temperaturen für max Positionsänderung"
         }
     }
 }

--- a/mixing-valve/locales/en-US/mixing-valve.json
+++ b/mixing-valve/locales/en-US/mixing-valve.json
@@ -13,7 +13,11 @@
             "open": "Open (100%)",
             "close": "Close (0%)",
             "heating": "Heating (normal)",
-            "cooling": "Cooling (inverted)"
+            "cooling": "Cooling (inverted)",
+
+            "precision": "Hysteresis (precision)",
+            "max_change_percent": "Max change",
+            "max_change_temp_difference": "Temp at max change"
         }
     }
 }

--- a/mixing-valve/mixing-valve.html
+++ b/mixing-valve/mixing-valve.html
@@ -11,6 +11,9 @@
             time_sampling: { value: 60 },
             off_mode: { value: "NOTHING" }, // NOTHING | OPEN | CLOSE
             valve_mode: { value: "HEATING" }, // HEATING | COOLING
+            precision: { value: 1.0 },
+            max_change_percent: { value: 1 },
+            max_change_temp_difference: { value: 20 },
         },
         inputs: 1,
         outputs: 3,
@@ -93,6 +96,52 @@
                         ],
                     }],
                 });
+
+            $("#node-input-precision")
+                  .css("max-width", "4rem")
+                  .spinner({
+                      min: 0.1,
+                      max: 1.0,
+                      step: 0.1,
+                      change: function (event, ui)
+                      {
+                          var value = parseFloat(this.value);
+                          value = isNaN(value) ? 0.0 : value;
+                          value = Math.max(value, parseFloat($(this).attr("aria-valuemin")));
+                          value = Math.min(value, parseFloat($(this).attr("aria-valuemax")));
+                          if (value !== this.value) $(this).spinner("value", value);
+                      },
+                  });
+
+            $("#node-input-max_change_percent")
+                  .css("max-width", "4rem")
+                  .spinner({
+                      min: 1,
+                      max: 20,
+                      change: function (event, ui)
+                      {
+                          var value = parseInt(this.value);
+                          value = isNaN(value) ? 0 : value;
+                          value = Math.max(value, parseInt($(this).attr("aria-valuemin")));
+                          value = Math.min(value, parseInt($(this).attr("aria-valuemax")));
+                          if (value !== this.value) $(this).spinner("value", value);
+                      },
+                  });
+
+            $("#node-input-max_change_temp_difference")
+                  .css("max-width", "4rem")
+                  .spinner({
+                      min: 1,
+                      max: 20,
+                      change: function (event, ui)
+                      {
+                          var value = parseInt(this.value);
+                          value = isNaN(value) ? 0 : value;
+                          value = Math.max(value, parseInt($(this).attr("aria-valuemin")));
+                          value = Math.min(value, parseInt($(this).attr("aria-valuemax")));
+                          if (value !== this.value) $(this).spinner("value", value);
+                      },
+                  });
         },
     });
 </script>
@@ -125,5 +174,17 @@
     <div class="form-row">
         <label for="node-input-valve_mode"><i class="fa fa-fire"></i> <span data-i18n="mixing-valve.ui.mode"></span></label>
         <input id="node-input-valve_mode" />
+    </div>
+    <div class="form-row">
+        <label for="node-input-precision"><i class="fa fa-sliders"></i> <span data-i18n="mixing-valve.ui.precision"></span></label>
+        <input id="node-input-precision" value="1.0" /> °C
+    </div>
+    <div class="form-row">
+        <label for="node-input-max_change_percent"><i class="fa fa-sliders"></i> <span data-i18n="mixing-valve.ui.max_change_percent"></span></label>
+        <input id="node-input-max_change_percent" value="2" /> %
+    </div>
+    <div class="form-row">
+        <label for="node-input-max_change_temp_difference"><i class="fa fa-sliders"></i> <span data-i18n="mixing-valve.ui.max_change_temp_difference"></span></label>
+        <input id="node-input-max_change_temp_difference" value="20" /> °C
     </div>
 </script>


### PR DESCRIPTION
Default histeresis of 1 degree will lead to broad temperature differences than expected in cases where more precise control is require -> value is exposed in node configuration with previous values as default. Also when using for much lower temperature differences on fully closed vs fully open (ex. input 35 and expected output 25) default values for change will lead to near 0 shifts -> values are exposed in node configuration with previous values as defaults.

Additionally added IntelliJ files to ignored files in git.